### PR TITLE
Options update

### DIFF
--- a/bin/groopm2
+++ b/bin/groopm2
@@ -5,7 +5,7 @@
 #                                                                             #
 #    Entry point. See groopm/groopm.py for internals                          #
 #                                                                             #
-#    Copyright (C) Michael Imelfort, Tim Lamberton                            #
+#    Copyright (C) Michael Imelfort, Tim Lamberton, Ben Woodcroft             #
 #                                                                             #
 ###############################################################################
 #                                                                             #
@@ -38,9 +38,9 @@
 #                                                                             #
 ###############################################################################
 
-__author__ = "Michael Imelfort, Tim Lamberton"
+__author__ = "Michael Imelfort, Tim Lamberton", "Ben Woodcroft"
 __copyright__ = "Copyright 2012-2015"
-__credits__ = ["Michael Imelfort", "Tim Lamberton"]
+__credits__ = ["Michael Imelfort", "Tim Lamberton", "Ben Woodcroft"]
 __license__ = "GPL3"
 __maintainer__ = "Tim Lamberton"
 __email__ = "t.lamberton@uq.edu.au"
@@ -67,7 +67,7 @@ from groopm import __version__
 
 class CustomHelpFormatter(argparse.HelpFormatter):
     #Some hack by Mike meaning we need to be careful if we ever update argparse.
-    
+
     def _split_lines(self, text, width):
         return text.splitlines()
 
@@ -101,11 +101,11 @@ class PrintHelpAction(argparse.Action):
     '''
     def __init__(self, nargs=0, *args, **kwargs):
         argparse.Action.__init__(self, *args, nargs=nargs, **kwargs)
-        
+
     def __call__(self, parser, *_args):
         self.print_help()
         parser.exit(1)
-       
+
     def print_help(_self):
         print '''\
 
@@ -116,26 +116,26 @@ class PrintHelpAction(argparse.Action):
    -------------------------------------------------------------------------
                                   version: {version}
    -------------------------------------------------------------------------
-   
+
     Typical workflow:
-    
+
     {groopm} parse        -> {parse}
     {groopm} core         -> {core}
     {groopm} extract      -> {extract}
-    
+
     Extra features:
-        
+
         Import / Export
-        
+
     {groopm} dump         -> {dump}
     {groopm} markers      -> {markers}
     {groopm} import       -> {import_}
-    
+
         Plotting
-        
+
     {groopm} plot         -> {plot}
     {groopm} explore      -> {explore}
-    
+
     USE: groopm OPTION -h to see detailed options
 '''.format(
             groopm="groopm2",
@@ -155,27 +155,26 @@ class PrintHelpAction(argparse.Action):
 
 class parse_command_configure:
     description="Parse raw data and save to disk"
-    
+
     def __init__(self, parser):
         parser.add_argument('dbname', help="name of the database being created")
         parser.add_argument('reference', help="fasta file containing bam reference sequences")
         parser.add_argument('bamfiles', nargs='+', help="bam files to parse")
         parser.add_argument('-m', '--markerfile', help="file with columns for contig names, marker genes and lineages")
-        parser.add_argument('--singlem', action="store_true", help="use SingleM to find marker genes in reference contigs")
         parser.add_argument('--graftm', action="store_true", help="use GraftM to find marker genes in reference contigs")
         parser.add_argument('--graftm_package_single_copy', default=[], nargs='+', help="use these GraftM packages to find single-copy marker genes")
         parser.add_argument('-t', '--threads', type=int, default=1, help="number of threads to use during BAM parsing")
         parser.add_argument('-f', '--force', action="store_true", default=False, help="overwrite existing DB file without prompting")
         parser.add_argument('-c', '--cutoff', type=int, default=500, help="cutoff contig size during parsing")
         parser.set_defaults(run=self)
-        
+
     def __call__(_self, options):
         timer = groopm.TimeKeeper()
         print "*******************************************************************************"
         print " [[GroopM %s]] Running in data parsing mode..." % __version__
         print "*******************************************************************************"
         dm = groopm.DataManager()
-                
+
         success = dm.createDB(
             timer,
             options.bamfiles,
@@ -197,13 +196,13 @@ def readable_int(s):
         for (i, suffix) in enumerate("KMGTPEZY"):
             if s.endswith(suffix):
                 return int(s[:-len(suffix)])*1000**(i+1)
-        raise        
-            
+        raise
+
 class core_command_configure:
     description = "Load saved data and make bin cores"
-    
+
     DEFAULT_SIZE = 1000000
-    
+
     def __init__(self, parser):
         parser.add_argument('dbname', help="name of the database to open")
         parser.add_argument('-c', '--cutoff', type=int, default=1500, help="cutoff contig size for core creation")
@@ -214,7 +213,7 @@ class core_command_configure:
         group.add_argument('--save_dists', action="store_true", help="save distance files")
         group.add_argument('--use_saved_dists', default="", help="prefix of saved distance files")
         parser.set_defaults(run=self)
-    
+
     def __call__(self, options):
         timer = groopm.TimeKeeper()
         print "*******************************************************************************"
@@ -230,11 +229,11 @@ class core_command_configure:
                savedDistsPrefix=options.use_saved_dists,
                keepDists=options.use_saved_dists!="" or options.save_dists,
                force=options.force)
-        
-        
+
+
 class extract_command_configure:
     description = "Extract contigs or reads based on bin affiliations"
-    
+
     def __init__(self, parser):
         parser.add_argument('dbname', help="name of the database to open")
         parser.add_argument('data', nargs='+', help="data file(s) to extract from, bam or fasta")
@@ -302,10 +301,10 @@ class extract_command_configure:
         else:
             raise ExtractModeNotAppropriateException("mode: "+ options.mode + " is unknown")
 
-                        
+
 class markers_command_configure:
     description="Print summary of binned contig marker information to text file"
-    
+
     def __init__(self, parser):
         parser.add_argument('dbname', help="name of the database to open")
         parser.add_argument('-b', '--bids', nargs='+', type=int, default=None, help="bin ids to use (None for all)")
@@ -328,14 +327,14 @@ class markers_command_configure:
         mx.extractMappingInfo(timer,
                               bids=bids,
                               prefix=options.prefix)
-            
+
 
 class dump_command_configure:
     description="Write database to text file"
-    
+
     DUMP_FIELDS = ['names', 'sizes', 'gc', 'bins', 'coverage', 'ncoverage', 'mers']
     DUMP_MARKER_FIELDS = ['contigs', 'markers', 'taxstrings']
-    
+
     def __init__(self, parser):
         parser.add_argument('dbname', help="name of the database to open")
         parser.add_argument('-f', '--fields', default="names,bins", help="fields to extract: Build a comma separated list from [%s] (or [%s] with --markers) or just use 'all'" % (", ".join(self.DUMP_FIELDS), ", ".join(self.DUMP_MARKER_FIELDS)))
@@ -381,13 +380,13 @@ class dump_command_configure:
                         options.outfile,
                         separator,
                         not options.no_headers)
-                    
+
 
 class binstat_command_configure:
     description="Write bin stats to text file"
-    
+
     DUMP_FIELDS = ['bins', 'points', 'sizes', 'lengths', 'gc', 'coverage', 'tags']
-    
+
     def __init__(self, parser):
         parser.add_argument('dbname', help="name of the database to open")
         parser.add_argument('-f', '--fields', default="bins,points,sizes,tags", help="fields to extract: Build a comma separated list from [names, mers, gc, coverage, tcoverage, ncoverage, lengths, bins] or just use 'all'")
@@ -462,14 +461,14 @@ class explore_command_configure:
         group.add_argument('--all_groups', action="store_true", help="plot all groups")
         group.add_argument('-b', '--bids', nargs='*', type=int, help="bin ids to plot")
         group.add_argument('-g', '--groups', nargs='*', help="groups to plot")
-        
+
         #parser.add_argument('--names', nargs='*', default=None, help="contig ids to highlight when plotting bins, or to plot if ORIGIN is 'names'")
         parser.add_argument('--origin', default="mediod", choices=["mediod", "max_length", "max_coverage", "max_density"], help="set how to choose plot origin")
         parser.add_argument('-p', '--prefix', default="", help="prefix to apply to output files")
         group = parser.add_mutually_exclusive_group()
         group.add_argument('-o', '--out_folder', default="", help="save plots in folder")
         group.add_argument('-i', '--interactive', action="store_true", help="interactive plot of bins or contigs")
-        
+
         parser.add_argument('--groupfile', default="", help="file with contig id and group id columns to import")
         parser.add_argument('-s', '--separator', default=",", help="data separator for GROUPFILE")
         parser.add_argument('--colormap', default="HSV", choices=["HSV", "Accent", "Blues", "Spectral", "Grayscale", "Discrete", "DiscretePaired"], help="set GC pc colormap")
@@ -490,9 +489,9 @@ class explore_command_configure:
             separator = '\t'
         else:
             separator = options.separator
-            
+
         centre_groups = options.all_groups or options.groups is not None
-            
+
         pm = groopm.ExplorePlotManager(options.dbname,
                                        folder=None if options.interactive else options.out_folder)
         pm.plot(timer,
@@ -507,8 +506,8 @@ class explore_command_configure:
                 rawDistances=options.raw_distances,
                 savedDistsPrefix=options.use_saved_dists,
                 keepDists=options.use_saved_dists!="" or options.save_dists)
-                   
-                           
+
+
 class plot_command_configure:
     description="Make cluster reachability plot"
 
@@ -519,7 +518,7 @@ class plot_command_configure:
         group.add_argument('--all_groups', action="store_true", help="plot all groups")
         group.add_argument('-b', '--bids', nargs='*', type=int, help="bin ids to plot")
         group.add_argument('-g', '--groups', nargs='*', help="groups to plot")
-        
+
         parser.add_argument('-o', '--out_file', default="REACH.png", help="name of save plot")
         parser.add_argument('-i', '--interactive', action="store_true", help="interatcive plot")
         parser.add_argument('--groupfile', default="", help="file with contig id and group id columns to import")
@@ -534,14 +533,14 @@ class plot_command_configure:
         print "*******************************************************************************"
 
         (folder, filename) = os.path.split(options.out_file)
-        
+
         if options.separator == '\\t':
             separator = '\t'
         else:
             separator = options.separator
-            
+
         centre_groups = options.all_groups or options.groups is not None
-            
+
         pm = groopm.ReachabilityPlotManager(options.dbname,
                                             folder=None if options.interactive else folder)
         pm.plot(timer,
@@ -551,7 +550,7 @@ class plot_command_configure:
                 groupfile=options.groupfile,
                 label="tag" if options.taxonomy else "bid",
                 separator=separator)
-                   
+
 
 #------------------------------------------------------------------------------
 #GroopM command
@@ -560,11 +559,11 @@ def groopm_command_configure(parser):
     parser.add_argument('-h', '--help', action=PrintHelpAction)
     parser.add_argument('-v', '--version', action="version",
         version="GroopM: version %s %s %s" % (__version__, __copyright__, __author__))
-        
+
     ##################################################
     # workflow subcommands
     ##################################################
-    
+
     subparsers = parser.add_subparsers()
     parse_subparser = subparsers.add_parser(
         "parse",
@@ -579,7 +578,7 @@ def groopm_command_configure(parser):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     core_command_configure(core_subparser)
-    
+
     extract_subparser = subparsers.add_parser(
         "extract",
         description=extract_command_configure.description,
@@ -607,21 +606,21 @@ def groopm_command_configure(parser):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     dump_command_configure(dump_subparser)
-    
+
     binstat_subparser = subparsers.add_parser(
         "binstat",
         description=binstat_command_configure.description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     binstat_command_configure(binstat_subparser)
-    
+
     markers_subparser = subparsers.add_parser(
         "markers",
         description=markers_command_configure.description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     markers_command_configure(markers_subparser)
-    
+
     import_subparser = subparsers.add_parser(
         "import",
         description=import_command_configure.description,
@@ -640,16 +639,16 @@ def groopm_command_configure(parser):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     plot_command_configure(plot_subparser)
-    
+
     explore_subparser = subparsers.add_parser(
         "explore",
         description=explore_command_configure.description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     explore_command_configure(explore_subparser)
-    
-    
-    
+
+
+
 if __name__ == '__main__':
 
     ##################################################
@@ -658,7 +657,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(add_help=False)
     groopm_command_configure(parser)
-    
+
     args = parser.parse_args()
 
     #-------------------------------------------------
@@ -686,4 +685,3 @@ if __name__ == '__main__':
 ###############################################################################
 ###############################################################################
 ###############################################################################
-

--- a/bin/groopm2
+++ b/bin/groopm2
@@ -156,19 +156,30 @@ class PrintHelpAction(argparse.Action):
 class parse_command_configure:
     description="Parse raw data and save to disk"
 
+    DEFAULT_GRAFTM_PACKAGE_SINGLE_COPY = []
+
     def __init__(self, parser):
         parser.add_argument('dbname', help="name of the database being created")
         parser.add_argument('reference', help="fasta file containing bam reference sequences")
         parser.add_argument('bamfiles', nargs='+', help="bam files to parse")
         parser.add_argument('-m', '--markerfile', help="file with columns for contig names, marker genes and lineages")
         parser.add_argument('--graftm', action="store_true", help="use GraftM to find marker genes in reference contigs")
-        parser.add_argument('--graftm_package_single_copy', default=[], nargs='+', help="use these GraftM packages to find single-copy marker genes")
+        parser.add_argument(
+            '--graftm_package_single_copy',
+            default=self.DEFAULT_GRAFTM_PACKAGE_SINGLE_COPY,
+            nargs='+',
+            help="use these GraftM packages to find single-copy marker genes. Requires --graftm.")
         parser.add_argument('-t', '--threads', type=int, default=1, help="number of threads to use during BAM parsing")
         parser.add_argument('-f', '--force', action="store_true", default=False, help="overwrite existing DB file without prompting")
         parser.add_argument('-c', '--cutoff', type=int, default=500, help="cutoff contig size during parsing")
         parser.set_defaults(run=self)
 
     def __call__(_self, options):
+        if not options.graftm and\
+           options.graftm_package_single_copy != parse_command_configure.DEFAULT_GRAFTM_PACKAGE_SINGLE_COPY:
+            print "If --graftm_package_single_copy is defined, then --graftm must be set."
+            sys.exit(1)
+
         timer = groopm.TimeKeeper()
         print "*******************************************************************************"
         print " [[GroopM %s]] Running in data parsing mode..." % __version__

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from distutils.core import setup
+from setuptools import setup
+
 from Cython.Build import cythonize
 import numpy as np
 
@@ -19,6 +20,8 @@ setup(
         "matplotlib >= 1.3.0",
         "tables >= 3.2.0"
     ],
+    setup_requires=['nose>=1.0'],
+    test_suite='nose.collector',
     include_dirs = [np.get_include()],
     ext_modules = cythonize("groopm/stream_ext.pyx"), 
 )


### PR DESCRIPTION
Hey,
Just a few options changes. You say --singlem and --graftm shouldn't both be specified, but I couldn't see how --singlem was even used at all in the code so I just removed it. Was that not a good idea?

Also, some tests failed:
```
$ nosetests
======================================================================
ERROR: Failure: ImportError (cannot import name permute_obs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/gnu/store/y3iyyshpll6vabz7l00fxvr9w441m4pq-profile/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/gnu/store/y3iyyshpll6vabz7l00fxvr9w441m4pq-profile/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/gnu/store/y3iyyshpll6vabz7l00fxvr9w441m4pq-profile/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/ben/git/GroopM/groopm/tests/test_hierarchy.py", line 35, in <module>
    from groopm.hierarchy import (maxscoresbelow,
ImportError: cannot import name permute_obs

======================================================================
ERROR: test_map.TestMapper.testGraftMMapper
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/gnu/store/y3iyyshpll6vabz7l00fxvr9w441m4pq-profile/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/ben/git/GroopM/groopm/tests/test_map.py", line 69, in testGraftMMapper
    (con_indices, markers, taxstrings) = mapper.getMappings(self.contigsFile, cid2Indices)
  File "/home/ben/git/GroopM/groopm/map.py", line 161, in getMappings
    read_tax_files = dict([self.mapPackage(contigFile, package) for package in self.packageList])
  File "/home/ben/git/GroopM/groopm/map.py", line 209, in mapPackage
    subprocess.check_call(cmd, shell=True)
  File "/gnu/store/dxssbrzj96gmha0sdslhsp0pm57l0im9-python-2.7.13/lib/python2.7/subprocess.py", line 186, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command 'graftM graft --forward /home/ben/git/GroopM/groopm/tests/map_data/contigs.fa --graftm_package /home/ben/git/GroopM/graftm_packages/DNGNGWU00001.gpkg --output_directory /home/ben/git/GroopM/groopm/tests/map_data/test_map/contigs_DNGNGWU00001 --verbosity 2 2> /dev/null' returned non-zero exit status 1

======================================================================
FAIL: test_db_upgrade.TestDBUpgrade.test_db_upgrade_v0
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/gnu/store/y3iyyshpll6vabz7l00fxvr9w441m4pq-profile/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/ben/git/GroopM/groopm/tests/test_db_upgrade.py", line 82, in test_db_upgrade_v0
    raise AssertionError("Upgrade script returned error code: %d" % proc.returncode)
AssertionError: Upgrade script returned error code: 1
-------------------- >> begin captured stdout << ---------------------
*******************************************************************************

              *** Upgrading GM DB from version 0 to version 1 ***

                            please be patient...

    Calculating and storing the kmerSig PCAs
*******************************************************************************
*******************************************************************************

              *** Upgrading GM DB from version 1 to version 2 ***

                            please be patient...

    Calculating and storing the kmer signature PCAs

Please specify fasta file containing the bam reference sequences: *******************************************************************************
*******************************************************************************

              *** Upgrading GM DB from version 2 to version 3 ***

                            please be patient...

    Calculating and storing variance of kmer signature PCAs
*******************************************************************************
*******************************************************************************

              *** Upgrading GM DB from version 3 to version 4 ***

                            please be patient...

    Adding chimeric flag for each bin.
    !!! Groopm core must be run again for this flag to be properly set. !!!
*******************************************************************************
*******************************************************************************

              *** Upgrading GM DB from version 4 to version 5 ***

                            please be patient...

    Saving transformed coverage profiles
    You will not need to re-run parse or core due to this change
*******************************************************************************
*******************************************************************************

              *** Upgrading GM DB from version 5 to version 6 ***

                            please be patient...

    Storing marker hits
    Re-run core to get better bins

Please specify fasta file containing the bam reference sequences: Mapping contigs
    Error upgrading database to version 6
Traceback (most recent call last):
  File "/home/ben/git/GroopM/groopm/tests/db_upgrade_data/run_db_upgrade.py", line 47, in <module>
    DataManager().checkAndUpgradeDB(dbFileName, timer, silent=False)
  File "/home/ben/git/GroopM/groopm/data3.py", line 557, in checkAndUpgradeDB
    upgrade_tasks[task](dbFileName)
  File "/home/ben/git/GroopM/groopm/data3.py", line 1007, in upgradeDB_5_to_6
    (contig_indices, marker_indices, marker_names, marker_counts, taxstrings) = mapper.getMappings(contig_file, cid2Indices)
  File "/home/ben/git/GroopM/groopm/data3.py", line 1862, in getMappings
    (con_indices, map_markers, map_taxstrings) = self._runMapper(contig_file, cid_2_indices, self._mode, working_directory)
  File "/home/ben/git/GroopM/groopm/data3.py", line 1840, in _runMapper
    mapper = GraftMMapper(working_directory, self._graftm_package_list, silent=True)
  File "/home/ben/git/GroopM/groopm/map.py", line 152, in __init__
    self.packageList = self.getDefaultPackages()
  File "/home/ben/git/GroopM/groopm/map.py", line 145, in getDefaultPackages
    return [os.path.join(GRAFTM_PACKAGE_DIR, name) for name in os.listdir(GRAFTM_PACKAGE_DIR) if name.endswith('.gpkg')];
OSError: [Errno 2] No such file or directory: '/home/ben/git/GroopM/graftm_packages'


--------------------- >> end captured stdout << ----------------------

======================================================================
FAIL: test_db_upgrade.TestDBUpgrade.test_db_upgrade_v5
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/gnu/store/y3iyyshpll6vabz7l00fxvr9w441m4pq-profile/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/ben/git/GroopM/groopm/tests/test_db_upgrade.py", line 91, in test_db_upgrade_v5
    raise AssertionError("Upgrade script returned error code: %d" % proc.returncode)
AssertionError: Upgrade script returned error code: 1
-------------------- >> begin captured stdout << ---------------------
*******************************************************************************

              *** Upgrading GM DB from version 5 to version 6 ***

                            please be patient...

    Storing marker hits
    Re-run core to get better bins

Please specify fasta file containing the bam reference sequences: Mapping contigs
    Error upgrading database to version 6
Traceback (most recent call last):
  File "/home/ben/git/GroopM/groopm/tests/db_upgrade_data/run_db_upgrade.py", line 47, in <module>
    DataManager().checkAndUpgradeDB(dbFileName, timer, silent=False)
  File "/home/ben/git/GroopM/groopm/data3.py", line 557, in checkAndUpgradeDB
    upgrade_tasks[task](dbFileName)
  File "/home/ben/git/GroopM/groopm/data3.py", line 1007, in upgradeDB_5_to_6
    (contig_indices, marker_indices, marker_names, marker_counts, taxstrings) = mapper.getMappings(contig_file, cid2Indices)
  File "/home/ben/git/GroopM/groopm/data3.py", line 1862, in getMappings
    (con_indices, map_markers, map_taxstrings) = self._runMapper(contig_file, cid_2_indices, self._mode, working_directory)
  File "/home/ben/git/GroopM/groopm/data3.py", line 1840, in _runMapper
    mapper = GraftMMapper(working_directory, self._graftm_package_list, silent=True)
  File "/home/ben/git/GroopM/groopm/map.py", line 152, in __init__
    self.packageList = self.getDefaultPackages()
  File "/home/ben/git/GroopM/groopm/map.py", line 145, in getDefaultPackages
    return [os.path.join(GRAFTM_PACKAGE_DIR, name) for name in os.listdir(GRAFTM_PACKAGE_DIR) if name.endswith('.gpkg')];
OSError: [Errno 2] No such file or directory: '/home/ben/git/GroopM/graftm_packages'


--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 23 tests in 551.329s
```
Are they known errors?